### PR TITLE
Allow options to be specified when creating a new TypedStruct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    typed_struct (0.1.1)
+    typed_struct (0.1.2)
       rbs (~> 1.0)
 
 GEM
@@ -9,7 +9,7 @@ GEM
   specs:
     diff-lcs (1.4.4)
     rake (13.0.3)
-    rbs (1.1.1)
+    rbs (1.2.1)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/lib/typed_struct/version.rb
+++ b/lib/typed_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TypedStruct < Struct
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/typed_struct_spec.rb
+++ b/spec/typed_struct_spec.rb
@@ -5,7 +5,47 @@ RSpec.describe TypedStruct do
     expect(TypedStruct::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  it "works for a variety of property types" do
+    Other = TypedStruct.new x: :y
+    Item = TypedStruct.new a: 1,
+                           b: String,
+                           c: Rbs("Array[Symbol]"),
+                           d: /abc/,
+                           e: (0..5),
+                           f: Other,
+                           g: "foo",
+                           h: Rbs("Array[Other]")
+    expect(
+      Item.new(a: 1,
+               b: "baz",
+               c: %i[oo aa],
+               d: "abcdef",
+               e: 3,
+               f: Other.new(x: :y),
+               g: "foo",
+               h: [Other.new(x: :y)])
+    ).to be_truthy
+  end
+
+  context "for key strictness" do
+    it "doesn't error on extra properties" do
+      Item1 = TypedStruct.with(strict_keys: false).new(foo: String)
+      expect(Item1.new(foo: "", bar: 0)).to be_truthy
+    end
+
+    it "errors with extra properties (explicit)" do
+      Item2 = TypedStruct.with(strict_keys: true).new(foo: String)
+      expect { Item2.new(foo: "", bar: 0) }.to raise_error ArgumentError
+    end
+
+    it "errors with extra properties (by default)" do
+      Item3 = TypedStruct.new(foo: String)
+      expect { Item3.new(foo: "", bar: 0) }.to raise_error ArgumentError
+    end
+
+    it "can still raise type errors" do
+      Item4 = TypedStruct.with(strict_keys: false).new(foo: String)
+      expect { Item4.new(foo: :abc) }.to raise_error TypedStruct::TypeError
+    end
   end
 end


### PR DESCRIPTION
Exact format tbc

`TypedStruct.with(strict_keys: true).new foo: String`

or could be

`TypedStruct.new({ strict_keys: true }, foo: String)`