### PR TITLE
Print warning when overriding TypedStructs existing methods

### DIFF
--- a/lib/typed_struct/version.rb
+++ b/lib/typed_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TypedStruct < Struct
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/typed_struct_spec.rb
+++ b/spec/typed_struct_spec.rb
@@ -5,7 +5,28 @@ RSpec.describe TypedStruct do
     expect(TypedStruct::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  context "on overriding native methods" do
+    before { $stdout = StringIO.new }
+
+    after { $stdout = STDOUT }
+
+    it "prints a warning for :class" do
+      TypedStruct.new class: String
+      expect($stdout.string).to start_with "*** WARNING *** property :class overrides a native method in TypedStruct"
+      expect($stdout.string).to include __FILE__
+    end
+
+    it "prints a warning for :length" do
+      TypedStruct.new length: String
+      expect($stdout.string).to start_with "*** WARNING *** property :length overrides a native method in TypedStruct"
+      expect($stdout.string).to include __FILE__
+    end
+
+    it "doesn't break if ignoring warning for :class" do
+      x = TypedStruct.new class: NilClass
+      expect(y = x.new(class: nil)).to be_truthy
+      expect(y.class).to be_nil
+      expect(y.__class__).to be_an_instance_of Class
+    end
   end
 end


### PR DESCRIPTION
This is a noted behaviour when using Structs and OpenStructs, and can lead to some strange bugs. This PR at least allows for you to be warned that this could happen. This PR also means that if you _do_ decide to ignore the warning and use one of these attributes, it shouldn't break at least (note `__class__` as an alias of `class` to ensure this)