### PR TITLE
Allow default values to be specified upon creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    typed_struct (0.1.2)
+    typed_struct (0.1.3)
       rbs (~> 1.0)
 
 GEM

--- a/lib/typed_struct/version.rb
+++ b/lib/typed_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TypedStruct < Struct
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/typed_struct_spec.rb
+++ b/spec/typed_struct_spec.rb
@@ -29,4 +29,50 @@ RSpec.describe TypedStruct do
       expect(y.__class__).to be_an_instance_of Class
     end
   end
+
+  context "when passing options" do
+    it "allows for default values" do
+      x = TypedStruct.new(
+        TypedStruct::Options.new(default: 5),
+        int: Integer,
+        str: String,
+      )
+      y = x.new str: "abc"
+      expect(y.str).to eq "abc"
+      expect(y.int).to eq 5
+    end
+
+    it "allows anything responding to [] to be passed as options" do
+      x = TypedStruct.new(
+        { default: 3 },
+        xyz: /foobar/,
+        abc: :abc,
+      )
+      y = x.new abc: :abc, xyz: "foobarbaz"
+      expect(y.abc).to eq :abc
+      expect(y.xyz).to eq "foobarbaz"
+    end
+
+    it "breaks if a missing type and the type of the default don't match" do
+      x = TypedStruct.new(
+        TypedStruct::Options.new(default: 1),
+        int: Integer,
+        str: String,
+      )
+
+      expect { x.new(int: 4) }.to raise_error "Unexpected type Integer for :str (expected String)"
+    end
+  end
+
+  context "when no options passed" do
+    it "defaults to nil for missing properties" do
+      x = TypedStruct.new abc: Rbs("String?")
+      expect(x.new.abc).to be_nil
+    end
+
+    it "errors if the missing property cannot be nil" do
+      x = TypedStruct.new abc: Rbs("String")
+      expect { x.new }.to raise_error "Unexpected type NilClass for :abc (expected String)"
+    end
+  end
 end


### PR DESCRIPTION
Usage:

```ruby
X = TypedStruct.new({ default: "empty" }, foo: String)
# or X = TypedStruct.new(TypedStruct::Options.new(default: "empty"), foo: String)
x = X.new
x.foo # "empty"
```

Current:

```ruby
X = TypedStruct.new(foo: String)
x = X.new # raises error because :foo will implicitly be nil
```

This change is backwards compatible, so the existing behaviour will still work the same way